### PR TITLE
Android integration

### DIFF
--- a/build_android.sh
+++ b/build_android.sh
@@ -25,13 +25,8 @@ ABIS=(
     "x86_64 amd64 $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/x86_64-linux-android$API_LEVEL-clang"
 )
 
-# export TOOLCHAIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64
-# export CC=$TOOLCHAIN/bin/aarch64-linux-android$API_LEVEL-clang
-# export CXX=$TOOLCHAIN/bin/aarch64-linux-android$API_LEVEL-clang++
 export CGO_ENABLED=1
 export GOOS=android
-# export CGO_CFLAGS="-I$ANDROID_NDK_HOME/sysroot/usr/include -target aarch64-none-linux-android$API_LEVEL"
-# export CGO_LDFLAGS="-target aarch64-none-linux-android$API_LEVEL"
 
 # Loop through each ABI and build
 for abi in "${ABIS[@]}"; do
@@ -43,12 +38,7 @@ for abi in "${ABIS[@]}"; do
     export CXX="$CC++"
 
     # Build the shared library
-    # go build -buildmode=c-shared -o "build/libdessl_$abi_name.so" main.go
-
     go build -buildmode=c-shared -ldflags="-w -s" -v -o "build/$abi_name/libdessl.so"
 
     echo "Done building for $abi_name."
 done
-
-# Сборка
-# go build -ldflags="-w -s" -v -o "build/libdessl.a"

--- a/build_android.sh
+++ b/build_android.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "$ANDROID_NDK_HOME" ]; then
+    echo "ERROR: ANDROID_NDK_HOME environment variable is not set"
+    echo "Please set it first:"
+    echo "export ANDROID_NDK_HOME=</path/to/your/ndk>"
+    echo "i.e export ANDROID_NDK_HOME=/Users/USERNAME/Library/Android/sdk/ndk/29.0.13113456"
+    exit 1
+fi
+
+if [ ! -d "$ANDROID_NDK_HOME" ]; then
+    echo "ERROR: NDK directory does not exist: $ANDROID_NDK_HOME"
+    exit 1
+fi
+
+export API_LEVEL=21
+
+# Define ABIs and their corresponding Go architectures and compilers
+ABIS=(
+    "armeabi-v7a arm $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi$API_LEVEL-clang"
+    "arm64-v8a arm64 $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android$API_LEVEL-clang"
+    "x86 386 $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android$API_LEVEL-clang"
+    "x86_64 amd64 $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/x86_64-linux-android$API_LEVEL-clang"
+)
+
+# export TOOLCHAIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64
+# export CC=$TOOLCHAIN/bin/aarch64-linux-android$API_LEVEL-clang
+# export CXX=$TOOLCHAIN/bin/aarch64-linux-android$API_LEVEL-clang++
+export CGO_ENABLED=1
+export GOOS=android
+# export CGO_CFLAGS="-I$ANDROID_NDK_HOME/sysroot/usr/include -target aarch64-none-linux-android$API_LEVEL"
+# export CGO_LDFLAGS="-target aarch64-none-linux-android$API_LEVEL"
+
+# Loop through each ABI and build
+for abi in "${ABIS[@]}"; do
+    read -r abi_name goarch cc <<< "$abi"
+    echo "Building for $abi_name..."
+
+    export GOARCH=$goarch
+    export CC=$cc
+    export CXX="$CC++"
+
+    # Build the shared library
+    # go build -buildmode=c-shared -o "build/libdessl_$abi_name.so" main.go
+
+    go build -buildmode=c-shared -ldflags="-w -s" -v -o "build/$abi_name/libdessl.so"
+
+    echo "Done building for $abi_name."
+done
+
+# Сборка
+# go build -ldflags="-w -s" -v -o "build/libdessl.a"

--- a/c_example/main.c
+++ b/c_example/main.c
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
     char *httpProxyHost = argv[4];
     int httpProxyPort = atoi(argv[5]);
 
-    c_startDeSSLServer(certDerPath, keyPemPath, localPort, httpProxyHost, httpProxyPort);
-    
+    c_startDeSSLServerWithCertFile(certDerPath, keyPemPath, localPort, httpProxyHost, httpProxyPort);
+
     return 0;
 }

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func startDeSSLServerWithCertFile(certDerPath string, keyPemPath string, localPo
 		return
 	}
 
-	startDeSSLServer(&certFactory, rootCert, rootKey, localPort, httpProxyHost, httpProxyPort)
+	startDeSSLServer(certFactory, rootCert, rootKey, localPort, httpProxyHost, httpProxyPort)
 }
 
 func startDeSSLServerWithCertData(certData []byte, keyData []byte, localPort int, httpProxyHost string, httpProxyPort int) {
@@ -81,10 +81,10 @@ func startDeSSLServerWithCertData(certData []byte, keyData []byte, localPort int
 		return
 	}
 
-	startDeSSLServer(&certFactory, rootCert, rootKey, localPort, httpProxyHost, httpProxyPort)
+	startDeSSLServer(certFactory, rootCert, rootKey, localPort, httpProxyHost, httpProxyPort)
 }
 
-func startDeSSLServer(certFactory *tlsutil.CertificateFactory, rootCert *x509.Certificate, rootKey *rsa.PrivateKey, localPort int, httpProxyHost string, httpProxyPort int) {
+func startDeSSLServer(certFactory tlsutil.CertificateFactory, rootCert *x509.Certificate, rootKey *rsa.PrivateKey, localPort int, httpProxyHost string, httpProxyPort int) {
 
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", localPort))
 	if err != nil {
@@ -101,7 +101,7 @@ func startDeSSLServer(certFactory *tlsutil.CertificateFactory, rootCert *x509.Ce
 			logger.ContextLogger(nil).WithError(err).Errorln("failed to accept connection")
 			continue
 		}
-		go handleConnection(conn, rootCert, rootKey, *certFactory, httpProxyHost, httpProxyPort)
+		go handleConnection(conn, rootCert, rootKey, certFactory, httpProxyHost, httpProxyPort)
 	}
 }
 


### PR DESCRIPTION
1. Add build script to assemble dynamic libraries for various Android ABIs (on Mac host only)
2. Chang leaf certificate start time to avoid time sync issues (`NotBefore` is now set to 1 hour earlier than `Now()`)
3. Add C API to allow to pass Root Cert and Root Key as array of bytes instead of paths to Cert/Key files.